### PR TITLE
README.mkd: Multiple changes to README

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -9,6 +9,14 @@ any data to disk. The paste is only active until the cache is cleared. this
 makes it ideal as a fast service for quick support. It also has extra Nginx
 hilighting features.
 
+Required Software
+-----------------
+
+Python modules (installable with `pip install`, if you have `pip` installed):  
+`bottle`, `mollom`, `Jinja2`
+
+Additional Software needed:  [`redis`](http://redis.io/download)
+
 Required Files
 --------------
 
@@ -25,7 +33,7 @@ conf/settings.cfg::
     relay_admin_chan=#channel-ops,#chanops
     relay_host=server.domain.tld
     relay_port=4040
-    check_spam=True
+    check_spam=False
     mollom_pub_key=ABC
     mollom_priv_key=XYZ
     python_server=auto


### PR DESCRIPTION
- [General Documentation Change] Add section for required third-party software and Python modules.  This is needed if someone wants to set this up in the future on their own, as this isn't detailed in depth and module installation would be a trial-and-error process to get them installed.
- [Critical - Provided Conf Change] Set `check_spam` to 'false' due to observed issues with the Mollom code here, in that the Mollom module no longer has a `MollomAPI` procedure.  Setting (and keeping) `check_spam` as `True` will prevent the application from running, so setting it to `False` by default will allow admins to get the application up and running without a massive amount of errors.
- [Suggested - Provided Conf Change] Set `relay_enabled` to `False` by default in the example config - this is done because it might not be a good idea to turn it on by default until the configuration has been set up and tested.
