### PR TITLE
Update README.mkd: Missing `relay_enabled` Change from Merge #6

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -28,7 +28,7 @@ conf/settings.cfg::
     port=80
     root_path=.
     url=http://p.ngx.cc/
-    relay_enabled=True
+    relay_enabled=False
     relay_chan=#channel-1,#channel-2
     relay_admin_chan=#channel-ops,#chanops
     relay_host=server.domain.tld


### PR DESCRIPTION
Whoopsies!  Forgot to mark `relay_enabled` as `False` in #6.  Guess a commit change went missing.

Reason (from #6):
* [Suggested - Provided Conf Change] Set `relay_enabled` to `False` by default in the example config - this is done because it might not be a good idea to turn it on by default until the configuration has been set up and tested.