### PR TITLE
Document the bot autoposting links

### DIFF
--- a/views/paste.html
+++ b/views/paste.html
@@ -70,7 +70,7 @@
   </table></form>
   <p class="note">
     All fields are required. Your paste will be deleted after four days.
-    <br />If you are not posting this for use in the IRC channel, please check Private.
+    <br />By default, the bot will post a link to your paste in the channel. If you are not posting this for use in the IRC channel, please check Private.
     <br />Click <a href="/about">About</a> to see more information.
   </p>
 {% endblock %}


### PR DESCRIPTION
I was (pleasantly) surprised to see the bot autopost a link to the paste once I'd pasted it - this just lets the user know that will happen :)